### PR TITLE
Fix Filter Bar Initial Display

### DIFF
--- a/ordering/static/css/index.css
+++ b/ordering/static/css/index.css
@@ -8,7 +8,7 @@ thead {
 }
 
 #show-filter-select {
-    visibility: hidden;
+    display: none;
 }
 
 .episode {


### PR DESCRIPTION
### Fixed
* The page jumping every time it rendered because of an incorrect display property