### PR TITLE
Add Black Lightning to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Data is also drawn from Wikipedia when necessary.
 * Supergirl
 * Vixen
 * Constantine
+* Black Lightning


### PR DESCRIPTION
Since the series is listed in the episode ordering, it should also be listed in the README.

See also #73 