### PR TITLE
Fixing episode order issue (#194) 

### DIFF
--- a/ordering/utils.py
+++ b/ordering/utils.py
@@ -124,7 +124,7 @@ def _handle_screening_day_error(episode_list):
 def _handle_air_time_error(episode_list):
     # handles when two episodes air on the same day
     seasons = ['', 'Midseason', 'Midseason', 'Midseason', 'Midseason', 'Midseason', 'Midseason',
-               'Summer', 'Summer', 'Summer', 'Fall', 'Fall', 'Fall']
+               'Summer', 'Summer', 'Fall', 'Fall', 'Fall', 'Fall']
     air_orders = {'Fall 2016': [(LEGENDS_OF_TOMORROW, VIXEN)],
                   'Midseason 2017': [(FLASH, LEGENDS_OF_TOMORROW)],
                   'Fall 2017': [(FLASH, LEGENDS_OF_TOMORROW)],
@@ -135,7 +135,10 @@ def _handle_air_time_error(episode_list):
                   'Midseason 2019': [(ARROW, BLACK_LIGHTNING),
                                      (LEGENDS_OF_TOMORROW, ARROW)],
                   'Fall 2019': [(BATWOMAN, SUPERGIRL),
-                                (FLASH, ARROW)]}
+                                (FLASH, ARROW)],
+                  'Midseason 2020': [(BATWOMAN, SUPERGIRL),
+                                     (ARROW, LEGENDS_OF_TOMORROW),
+                                     (FLASH, LEGENDS_OF_TOMORROW)]}
 
     for i in range(len(episode_list)-1):
         curr_ep = episode_list[i]


### PR DESCRIPTION
Updating episode order config dictionary with Midseason 2020 air schedule to same-day ordering issues